### PR TITLE
Add `lastUpdatedAt` to sync endpoints

### DIFF
--- a/Common/Models/Shows/TraktWatchedShow.swift
+++ b/Common/Models/Shows/TraktWatchedShow.swift
@@ -13,12 +13,14 @@ public struct TraktWatchedShow: Codable {
     // Extended: Min
     public let plays: Int // Total number of plays
     public let lastWatchedAt: Date?
+    public let lastUpdatedAt: Date?
     public let show: TraktShow
     public let seasons: [TraktWatchedSeason]
     
     enum CodingKeys: String, CodingKey {
         case plays
         case lastWatchedAt = "last_watched_at"
+        case lastUpdatedAt = "last_updated_at"
         case show
         case seasons
     }

--- a/Common/Models/Sync/TraktCollectedItem.swift
+++ b/Common/Models/Sync/TraktCollectedItem.swift
@@ -11,6 +11,7 @@ import Foundation
 public struct TraktCollectedItem: Codable {
     
     public var lastCollectedAt: Date
+    public let lastUpdatedAt: Date?
     
     public var movie: TraktMovie?
     public var show: TraktShow?
@@ -19,6 +20,7 @@ public struct TraktCollectedItem: Codable {
     enum CodingKeys: String, CodingKey {
         case lastCollectedAt = "last_collected_at" // Can be last_collected_at / collected_at though
         case movieLastCollectAt = "collected_at"
+        case lastUpdatedAt = "last_updated_at"
         case movie
         case show
         case seasons
@@ -30,6 +32,7 @@ public struct TraktCollectedItem: Codable {
         movie = try container.decodeIfPresent(TraktMovie.self, forKey: .movie)
         show = try container.decodeIfPresent(TraktShow.self, forKey: .show)
         seasons = try container.decodeIfPresent([TraktCollectedSeason].self, forKey: .seasons)
+        lastUpdatedAt = try container.decodeIfPresent(Date.self, forKey: .lastUpdatedAt)
 
         do {
             self.lastCollectedAt = try container.decode(Date.self, forKey: .lastCollectedAt)


### PR DESCRIPTION
Adds support for the missing `last_updated_at` timestamps to `sync/watched` and `sync/collection` endpoints.

Those are required for a reliable sync, as the `last_collected_at ` and `last_watched_at` can be set to past dates by the user.

https://trakt.docs.apiary.io/#reference/sync/get-collection/get-collection
https://trakt.docs.apiary.io/#reference/sync/get-watched/get-watched