### PR TITLE
Add swift package manager support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,27 @@
+// swift-tools-version:5.0
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "TraktKit",
+    platforms: [
+        .macOS(.v10_12),
+        .iOS(.v10),
+        .tvOS(.v10),
+        .watchOS(.v3)
+    ],
+    products: [
+        .library(
+            name: "TraktKit",
+            targets: ["TraktKit"]),
+    ],
+    targets: [
+        .target(
+            name: "TraktKit",
+            dependencies: [],
+            path: "Common"
+            )
+    ],
+    swiftLanguageVersions: [.v5]
+)


### PR DESCRIPTION
Now that Xcode 11 has support for swift package manager it'll be cool if TraktKit supported it. This PR adds the manifest file with some basic settings I think should be checked and tested.

Things to note:

- Including Common will be enough?
- Does TraktKit support all these platforms?