### PR TITLE
Add missing TraktUser fields

### DIFF
--- a/Common/Models/Users/TraktUser.swift
+++ b/Common/Models/Users/TraktUser.swift
@@ -9,13 +9,14 @@
 import Foundation
 
 public struct User: Codable {
-    
+
     // Min
     public let username: String?
     public let isPrivate: Bool
     public let name: String?
     public let isVIP: Bool?
     public let isVIPEP: Bool?
+    public let ids: IDs
     
     // Full
     public let joinedAt: Date?
@@ -23,6 +24,7 @@ public struct User: Codable {
     public let about: String?
     public let gender: String?
     public let age: Int?
+    public let images: Images?
     
     // VIP
     public let vipOG: Bool?
@@ -34,12 +36,26 @@ public struct User: Codable {
         case name
         case isVIP = "vip"
         case isVIPEP = "vip_ep"
+        case ids
         case joinedAt = "joined_at"
         case location
         case about
         case gender
         case age
+        case images
         case vipOG = "vip_og"
         case vipYears = "vip_years"
+    }
+
+    public struct IDs: Codable {
+        public let slug: String
+    }
+
+    public struct Images: Codable {
+        public let avatar: Image
+    }
+
+    public struct Image: Codable {
+        public let full: String
     }
 }


### PR DESCRIPTION
This PR adds the missing `ids` and `images` fields to `TraktUser` ([documentation](https://trakt.docs.apiary.io/#reference/users/profile/get-user-profile)).