### PR TITLE
Fix TraktCollectedItem metadata audio enum in tests

### DIFF
--- a/TraktKitTests/UserTests.swift
+++ b/TraktKitTests/UserTests.swift
@@ -357,7 +357,7 @@ class UserTests: XCTestCase {
                     XCTAssertEqual(metadata.mediaType, .bluray)
                     XCTAssertNil(metadata.resolution)
                     XCTAssertNil(metadata.hdr)
-                    XCTAssertEqual(metadata.audio, .dtsHD)
+                    XCTAssertEqual(metadata.audio, .dtsHDMA)
                     XCTAssertNil(metadata.audioChannels)
                     XCTAssertFalse(metadata.is3D)
                 } else {


### PR DESCRIPTION
> TraktKit/TraktKitTests/UserTests.swift:360:53: Reference to member 'dtsHD' cannot be resolved without a contextual type

Change was likely missed as part of a99703bf. Should fix failing test suite.