### PR TITLE
Set up Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on: [push]
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        platform: [macOS-10.14]
+        xcode: [11.3]
+
+    runs-on: ${{ matrix.platform }}
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_${{ matrix.xcode }}.app/Contents/Developer
+
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: Print Xcode version
+        run: xcodebuild -version -sdk
+
+      - name: Test
+        run: xcodebuild -project TraktKit.xcodeproj -scheme TraktKit test ENABLE_HARDENED_RUNTIME=NO CODE_SIGN_STYLE=Manual CODE_SIGN_IDENTITY=


### PR DESCRIPTION
Sets up CI via [GitHub Actions](https://github.com/features/actions).

Build is currently failing due to #39. [See example output on my fork](https://github.com/josh/TraktKit/commit/8cff4910cc368e3b69df17623e1479c51158e67e/checks?check_suite_id=400775345).

GitHub's CI is free and builtin, but I also understand if you rather set it up with another provider. No worries. Thanks 🙏 