### PR TITLE
Implement not_found result struct

### DIFF
--- a/Common/Models/Sync/AddRatingsResult.swift
+++ b/Common/Models/Sync/AddRatingsResult.swift
@@ -10,7 +10,7 @@ import Foundation
 
 public struct AddRatingsResult: Codable {
     public let added: Added
-//    public let notFound: NotFound
+    public let notFound: NotFound
 
     public struct Added: Codable {
         public let movies: Int
@@ -18,16 +18,20 @@ public struct AddRatingsResult: Codable {
         public let seasons: Int
         public let episodes: Int
     }
-    
-    public struct NotFound: Codable {
-        public let movies: [ID]
-        public let shows: [ID]
-        public let seasons: [ID]
-        public let episodes: [ID]
+
+    public struct NotFoundItem: Codable {
+        public let ids: ID
     }
-    
+
+    public struct NotFound: Codable {
+        public let movies: [NotFoundItem]
+        public let shows: [NotFoundItem]
+        public let seasons: [NotFoundItem]
+        public let episodes: [NotFoundItem]
+    }
+
     enum CodingKeys: String, CodingKey {
         case added
-//        case notFound = "not_found"
+        case notFound = "not_found"
     }
 }

--- a/Common/Models/Sync/AddToCollectionResult.swift
+++ b/Common/Models/Sync/AddToCollectionResult.swift
@@ -12,24 +12,28 @@ public struct AddToCollectionResult: Codable {
     let added: Added
     let updated: Added
     let existing: Added
-//    let notFound: NotFound
+    let notFound: NotFound
 
     public struct Added: Codable {
         let movies: Int
         let episodes: Int
     }
-    
-    public struct NotFound: Codable {
-        let movies: [ID]
-        let shows: [ID]
-        let seasons: [ID]
-        let episodes: [ID]
+
+    public struct NotFoundItem: Codable {
+        let ids: ID
     }
-    
+
+    public struct NotFound: Codable {
+        let movies: [NotFoundItem]
+        let shows: [NotFoundItem]
+        let seasons: [NotFoundItem]
+        let episodes: [NotFoundItem]
+    }
+
     enum CodingKeys: String, CodingKey {
         case added
         case updated
         case existing
-//        case notFound = "not_found"
+        case notFound = "not_found"
     }
 }

--- a/Common/Models/Sync/RemoveFromCollectionResult.swift
+++ b/Common/Models/Sync/RemoveFromCollectionResult.swift
@@ -10,22 +10,26 @@ import Foundation
 
 public struct RemoveFromCollectionResult: Codable {
     public let deleted: deleted
-//    public let notFound: NotFound
+    public let notFound: NotFound
 
     public struct deleted: Codable {
         let movies: Int
         let episodes: Int
     }
-    
-    public struct NotFound: Codable {
-        let movies: [ID]
-        let shows: [ID]
-        let seasons: [ID]
-        let episodes: [ID]
+
+    public struct NotFoundItem: Codable {
+        let ids: ID
     }
-    
+
+    public struct NotFound: Codable {
+        let movies: [NotFoundItem]
+        let shows: [NotFoundItem]
+        let seasons: [NotFoundItem]
+        let episodes: [NotFoundItem]
+    }
+
     enum CodingKeys: String, CodingKey {
         case deleted
-//        case notFound = "not_found"
+        case notFound = "not_found"
     }
 }

--- a/Common/Models/Sync/RemoveFromWatchlistResult.swift
+++ b/Common/Models/Sync/RemoveFromWatchlistResult.swift
@@ -10,7 +10,7 @@ import Foundation
 
 public struct RemoveFromWatchlistResult: Codable {
     let deleted: Deleted
-//    let notFound: NotFound
+    let notFound: NotFound
 
     public struct Deleted: Codable {
         let movies: Int
@@ -18,16 +18,21 @@ public struct RemoveFromWatchlistResult: Codable {
         let seasons: Int
         let episodes: Int
     }
-    
-    public struct NotFound: Codable {
-        let movies: [ID]
-        let shows: [ID]
-        let seasons: [ID]
-        let episodes: [ID]
+
+    public struct NotFoundItem: Codable {
+        let ids: ID
     }
-    
+
+    public struct NotFound: Codable {
+        let movies: [NotFoundItem]
+        let shows: [NotFoundItem]
+        let seasons: [NotFoundItem]
+        let episodes: [NotFoundItem]
+    }
+
+
     enum CodingKeys: String, CodingKey {
         case deleted
-//        case notFound = "not_found"
+        case notFound = "not_found"
     }
 }

--- a/Common/Models/Sync/RemoveRatingsResult.swift
+++ b/Common/Models/Sync/RemoveRatingsResult.swift
@@ -10,7 +10,7 @@ import Foundation
 
 public struct RemoveRatingsResult: Codable {
     public let deleted: Deleted
-//    public let notFound: NotFound
+    public let notFound: NotFound
 
     public struct Deleted: Codable {
         public let movies: Int
@@ -18,16 +18,20 @@ public struct RemoveRatingsResult: Codable {
         public let seasons: Int
         public let episodes: Int
     }
-    
-    public struct NotFound: Codable {
-        public let movies: [ID]
-        public let shows: [ID]
-        public let seasons: [ID]
-        public let episodes: [ID]
+
+    public struct NotFoundItem: Codable {
+        public let ids: ID
     }
-    
+
+    public struct NotFound: Codable {
+        public let movies: [NotFoundItem]
+        public let shows: [NotFoundItem]
+        public let seasons: [NotFoundItem]
+        public let episodes: [NotFoundItem]
+    }
+
     enum CodingKeys: String, CodingKey {
         case deleted
-//        case notFound = "not_found"
+        case notFound = "not_found"
     }
 }

--- a/Common/Models/Users/ListItemPostResult.swift
+++ b/Common/Models/Users/ListItemPostResult.swift
@@ -11,7 +11,7 @@ import Foundation
 public struct ListItemPostResult: Codable {
     let added: Added
     let existing: Added
-//    let notFound: NotFound
+    let notFound: NotFound
 
     public struct Added: Codable {
         let movies: Int
@@ -20,18 +20,21 @@ public struct ListItemPostResult: Codable {
         let episodes: Int
         let people: Int
     }
-    
-    public struct NotFound: Codable {
-        let movies: [ID]
-        let shows: [ID]
-        let seasons: [ID]
-        let episodes: [ID]
-        let people: [ID]
+
+    public struct NotFoundItem: Codable {
+        let ids: ID
     }
-    
+
+    public struct NotFound: Codable {
+        let movies: [NotFoundItem]
+        let shows: [NotFoundItem]
+        let seasons: [NotFoundItem]
+        let episodes: [NotFoundItem]
+    }
+
     enum CodingKeys: String, CodingKey {
         case added
         case existing
-//        case notFound = "not_found"
+        case notFound = "not_found"
     }
 }

--- a/Common/Models/Users/RemoveListItemResult.swift
+++ b/Common/Models/Users/RemoveListItemResult.swift
@@ -10,7 +10,7 @@ import Foundation
 
 public struct RemoveListItemResult: Codable {
     let deleted: Added
-//    let notFound: NotFound
+    let notFound: NotFound
 
     public struct Added: Codable {
         let movies: Int
@@ -19,17 +19,20 @@ public struct RemoveListItemResult: Codable {
         let episodes: Int
         let people: Int
     }
-    
-    public struct NotFound: Codable {
-        let movies: [ID]
-        let shows: [ID]
-        let seasons: [ID]
-        let episodes: [ID]
-        let people: [ID]
+
+    public struct NotFoundItem: Codable {
+        let ids: ID
     }
-    
+
+    public struct NotFound: Codable {
+        let movies: [NotFoundItem]
+        let shows: [NotFoundItem]
+        let seasons: [NotFoundItem]
+        let episodes: [NotFoundItem]
+    }
+
     enum CodingKeys: String, CodingKey {
         case deleted
-//        case notFound = "not_found"
+        case notFound = "not_found"
     }
 }


### PR DESCRIPTION
Looks like the `not_found` key was a WIP progress. Maybe something changed between when it was originally stubbed out, but the not found response is slightly different than originally structured. The item arrays are actually "items with ids" rather than an array of ids.

The test json file is actually correct.

https://github.com/MaxHasADHD/TraktKit/blob/a99703bf93d060843ac51258e4971a4f5174033e/TraktKitTests/Models/Sync/test_add_items_to_collection.json#L14-L31

This implement might be an okay start. There are some additional fields that could be part of `NotFoundItem`. The API seems to return the item object as sent in the request. So it may even have a title, year, etc. The ideal thing might be to re-use the same request struct as it's simply mirrored back. However that doesn't seem to be modeled either. It's just `RawJSON`.

Let me know what you're thinking. Thanks!