### PR TITLE
Add search years range filter

### DIFF
--- a/Common/Models/Filters.swift
+++ b/Common/Models/Filters.swift
@@ -26,6 +26,10 @@ public extension TraktManager {
          */
         case year(year: NSNumber)
         /**
+         4 digit year range.
+         */
+        case years(year: ClosedRange<Int>)
+        /**
          Genre slugs.
          */
         case genres(genres: [String])
@@ -50,6 +54,8 @@ public extension TraktManager {
             switch self {
             case .year(let year):
                 return ("years", "\(year)")
+            case .years(let years):
+                return ("years", "\(years.lowerBound)-\(years.upperBound)")
             case .genres(let genres):
                 return ("genres", genres.joined(separator: ","))
             case .languages(let languages):


### PR DESCRIPTION
Searching Trakt by year also supports a year range.

```swift
// Find all Batman movies from the 1980s
TraktManager.sharedManager.search(query: "Batman", types: [.movie], extended: nil, pagination: nil,
  filters: [.years(1980...1989], fields: nil)
```
