### PR TITLE
Conforming all models to Hashable

### DIFF
--- a/Common/Models/Authentication/AuthenticationInfo.swift
+++ b/Common/Models/Authentication/AuthenticationInfo.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct AuthenticationInfo: Decodable {
+public struct AuthenticationInfo: Decodable, Hashable {
     public let accessToken: String
     public let tokenType: String
     public let expiresIn: TimeInterval

--- a/Common/Models/Calendar/CalendarMovie.swift
+++ b/Common/Models/Calendar/CalendarMovie.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct CalendarMovie: Codable {
+public struct CalendarMovie: Codable, Hashable {
     public let released: Date
     public let movie: TraktMovie
 }

--- a/Common/Models/Calendar/CalendarShow.swift
+++ b/Common/Models/Calendar/CalendarShow.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct CalendarShow: Codable {
+public struct CalendarShow: Codable, Hashable {
     let firstAired: Date
     let episode: TraktEpisode
     let show: TraktShow

--- a/Common/Models/Certifications/Certification.swift
+++ b/Common/Models/Certifications/Certification.swift
@@ -8,14 +8,14 @@
 
 import Foundation
 
-public struct Certifications: Codable {
+public struct Certifications: Codable, Hashable {
     let us: [Certification]
     
     enum CodingKeys: String, CodingKey {
         case us
     }
     
-    struct Certification: Codable {
+    struct Certification: Codable, Hashable {
         let name: String
         let slug: String
         let description: String

--- a/Common/Models/Checkin/TraktCheckin.swift
+++ b/Common/Models/Checkin/TraktCheckin.swift
@@ -8,13 +8,13 @@
 
 import Foundation
 
-public struct ShareSettings: Codable {
+public struct ShareSettings: Codable, Hashable {
     public let facebook: Bool
     public let twitter: Bool
     public let tumblr: Bool
 }
 
-public struct TraktCheckin: Codable {
+public struct TraktCheckin: Codable, Hashable {
     
     /// Trakt History ID
     public let id: Int

--- a/Common/Models/Comments/TraktAttachedMediaItem.swift
+++ b/Common/Models/Comments/TraktAttachedMediaItem.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct TraktAttachedMediaItem: Codable {
+public struct TraktAttachedMediaItem: Codable, Hashable {
     public let type: String
     public let movie: TraktMovie?
     public let show: TraktShow?

--- a/Common/Models/Comments/TraktComment.swift
+++ b/Common/Models/Comments/TraktComment.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct Comment: Codable {
+public struct Comment: Codable, Hashable {
     public let id: Int
     public let parentId: Int
     public let createdAt: Date

--- a/Common/Models/Comments/TraktCommentLikedUser.swift
+++ b/Common/Models/Comments/TraktCommentLikedUser.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct TraktCommentLikedUser: Codable {
+public struct TraktCommentLikedUser: Codable, Hashable {
     public let likedAt: Date
     public let user: User
 

--- a/Common/Models/Comments/TraktTrendingComments.swift
+++ b/Common/Models/Comments/TraktTrendingComments.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct TraktTrendingComment: Codable {
+public struct TraktTrendingComment: Codable, Hashable {
     public let type: String
     public let comment: Comment
     public let movie: TraktMovie?

--- a/Common/Models/Genres/Genre.swift
+++ b/Common/Models/Genres/Genre.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct Genres: Codable {
+public struct Genres: Codable, Hashable {
     public let name: String
     public let slug: String
 }

--- a/Common/Models/Movies/TraktAnticipatedMovie.swift
+++ b/Common/Models/Movies/TraktAnticipatedMovie.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct TraktAnticipatedMovie: Codable {
+public struct TraktAnticipatedMovie: Codable, Hashable {
     // Extended: Min
     public let listCount: Int
     public let movie: TraktMovie

--- a/Common/Models/Movies/TraktBoxOfficeMovie.swift
+++ b/Common/Models/Movies/TraktBoxOfficeMovie.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct TraktBoxOfficeMovie: Codable {
+public struct TraktBoxOfficeMovie: Codable, Hashable {
     // Extended: Min
     public let revenue: Int
     public let movie: TraktMovie

--- a/Common/Models/Movies/TraktDVDReleaseMovie.swift
+++ b/Common/Models/Movies/TraktDVDReleaseMovie.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct TraktDVDReleaseMovie: Codable {
+public struct TraktDVDReleaseMovie: Codable, Hashable {
     // Extended: Min
     public let released: Date
     public let movie: TraktMovie

--- a/Common/Models/Movies/TraktMostMovie.swift
+++ b/Common/Models/Movies/TraktMostMovie.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct TraktMostMovie: Codable {
+public struct TraktMostMovie: Codable, Hashable {
 
     // Extended: Min
     public let watcherCount: Int

--- a/Common/Models/Movies/TraktMovie.swift
+++ b/Common/Models/Movies/TraktMovie.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct TraktMovie: Codable {
+public struct TraktMovie: Codable, Hashable {
     // Extended: Min
     public let title: String
     public let year: Int?

--- a/Common/Models/Movies/TraktMovieRelease.swift
+++ b/Common/Models/Movies/TraktMovieRelease.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct TraktMovieRelease: Codable {
+public struct TraktMovieRelease: Codable, Hashable {
     let country: String
     let certification: String
     let releaseDate: Date

--- a/Common/Models/Movies/TraktMovieTranslation.swift
+++ b/Common/Models/Movies/TraktMovieTranslation.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct TraktMovieTranslation: Codable {
+public struct TraktMovieTranslation: Codable, Hashable {
     public let title: String
     public let overview: String
     public let tagline: String

--- a/Common/Models/Movies/TraktTrendingMovie.swift
+++ b/Common/Models/Movies/TraktTrendingMovie.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct TraktTrendingMovie: Codable {
+public struct TraktTrendingMovie: Codable, Hashable {
     // Extended: Min
     public let watchers: Int
     public let movie: TraktMovie

--- a/Common/Models/Movies/TraktWatchedMovie.swift
+++ b/Common/Models/Movies/TraktWatchedMovie.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct TraktWatchedMovie: Codable {
+public struct TraktWatchedMovie: Codable, Hashable {
     // Extended: Min
     public let plays: Int // Total number of plays
     public let lastWatchedAt: Date

--- a/Common/Models/Pagination.swift
+++ b/Common/Models/Pagination.swift
@@ -11,7 +11,7 @@ import Foundation
 /**
  Some methods are paginated. By default, 1 page of 10 items will be returned. You can send these values by adding `?page={page}&limit={limit}` to the URL.
  */
-public struct Pagination {
+public struct Pagination: Hashable {
     /// Number of page of results to be returned.
     public let page: Int
     /// Number of results to return per page.

--- a/Common/Models/People/CastAndCrew.swift
+++ b/Common/Models/People/CastAndCrew.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct CastAndCrew {
+public struct CastAndCrew: Hashable {
     public let cast: [CastMember]?
     public let directors: [CrewMember]?
     public let writers: [CrewMember]?

--- a/Common/Models/People/Person.swift
+++ b/Common/Models/People/Person.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 // Actor/Actress/Crew member
-public struct Person: Codable {
+public struct Person: Codable, Hashable {
     // Extended: Min
     public let name: String
     public let ids: ID

--- a/Common/Models/People/TraktCastMember.swift
+++ b/Common/Models/People/TraktCastMember.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct CastMember: Codable {
+public struct CastMember: Codable, Hashable {
     public let character: String
     public let person: Person?
     public let movie: TraktMovie?

--- a/Common/Models/People/TraktCrewMember.swift
+++ b/Common/Models/People/TraktCrewMember.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct CrewMember: Codable {
+public struct CrewMember: Codable, Hashable {
     public let job: String
     public let person: Person?
     public let movie: TraktMovie?

--- a/Common/Models/Scrobbble/ScrobbleResult.swift
+++ b/Common/Models/Scrobbble/ScrobbleResult.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct ScrobbleResult: Codable {
+public struct ScrobbleResult: Codable, Hashable {
     let id: Int
     let action: String
     let progress: Float

--- a/Common/Models/Shared/Alias.swift
+++ b/Common/Models/Shared/Alias.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct Alias: Codable {
+public struct Alias: Codable, Hashable {
     let title: String
     let country: String
 }

--- a/Common/Models/Shared/RatingDistribution.swift
+++ b/Common/Models/Shared/RatingDistribution.swift
@@ -8,12 +8,12 @@
 
 import Foundation
 
-public struct RatingDistribution: Codable {
+public struct RatingDistribution: Codable, Hashable {
     public let rating: Double
     public let votes: Int
     public let distribution: Distribution
     
-    public struct Distribution: Codable {
+    public struct Distribution: Codable, Hashable {
         public let one: Int
         public let two: Int
         public let three: Int

--- a/Common/Models/Shared/Update.swift
+++ b/Common/Models/Shared/Update.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct Update: Codable {
+public struct Update: Codable, Hashable {
     public let updatedAt: Date
     public let movie: TraktMovie?
     public let show: TraktShow?

--- a/Common/Models/Shows/ShowCollectionProgress.swift
+++ b/Common/Models/Shows/ShowCollectionProgress.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct ShowCollectionProgress: Codable {
+public struct ShowCollectionProgress: Codable, Hashable {
     
     public let aired: Int
     public let completed: Int
@@ -26,14 +26,14 @@ public struct ShowCollectionProgress: Codable {
         case nextEpisode = "next_episode"
     }
     
-    public struct CollectedSeason: Codable {
+    public struct CollectedSeason: Codable, Hashable {
         let number: Int
         let aired: Int
         let completed: Int
         let episodes: [CollectedEpisode]
     }
     
-    public struct CollectedEpisode: Codable {
+    public struct CollectedEpisode: Codable, Hashable {
         let number: Int
         let completed: Bool
         let collectedAt: Date?

--- a/Common/Models/Shows/TraktAnticipatedShow.swift
+++ b/Common/Models/Shows/TraktAnticipatedShow.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct TraktAnticipatedShow: Codable {
+public struct TraktAnticipatedShow: Codable, Hashable {
     
     // Extended: Min
     public let listCount: Int

--- a/Common/Models/Shows/TraktEpisode.swift
+++ b/Common/Models/Shows/TraktEpisode.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct TraktEpisode: Codable {
+public struct TraktEpisode: Codable, Hashable {
     
     // Extended: Min
     public let season: Int

--- a/Common/Models/Shows/TraktEpisodeTranslation.swift
+++ b/Common/Models/Shows/TraktEpisodeTranslation.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct TraktEpisodeTranslation: Codable {
+public struct TraktEpisodeTranslation: Codable, Hashable {
     public let title: String
     public let overview: String
     public let language: String

--- a/Common/Models/Shows/TraktMostShow.swift
+++ b/Common/Models/Shows/TraktMostShow.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 /// Used for most played, watched, and collected shows
-public struct TraktMostShow: Codable {
+public struct TraktMostShow: Codable, Hashable {
     
     // Extended: Min
     public let watcherCount: Int

--- a/Common/Models/Shows/TraktSeason.swift
+++ b/Common/Models/Shows/TraktSeason.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct TraktSeason: Codable {
+public struct TraktSeason: Codable, Hashable {
     
     // Extended: Min
     public let number: Int

--- a/Common/Models/Shows/TraktShow.swift
+++ b/Common/Models/Shows/TraktShow.swift
@@ -8,13 +8,13 @@
 
 import Foundation
 
-public struct Airs: Codable {
+public struct Airs: Codable, Hashable {
     public let day: String?
     public let time: String?
     public let timezone: String?
 }
 
-public struct TraktShow: Codable {
+public struct TraktShow: Codable, Hashable {
     
     // Extended: Min
     public let title: String

--- a/Common/Models/Shows/TraktShowTranslation.swift
+++ b/Common/Models/Shows/TraktShowTranslation.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct TraktShowTranslation: Codable {
+public struct TraktShowTranslation: Codable, Hashable {
     public let title: String
     public let overview: String
     public let language: String

--- a/Common/Models/Shows/TraktTrendingShow.swift
+++ b/Common/Models/Shows/TraktTrendingShow.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct TraktTrendingShow: Codable {
+public struct TraktTrendingShow: Codable, Hashable {
     
     // Extended: Min
     public let watchers: Int

--- a/Common/Models/Shows/TraktWatchedEpisodes.swift
+++ b/Common/Models/Shows/TraktWatchedEpisodes.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct TraktWatchedEpisodes: Codable {
+public struct TraktWatchedEpisodes: Codable, Hashable {
     // Extended: Min
     public let number: Int
     public let plays: Int

--- a/Common/Models/Shows/TraktWatchedProgress.swift
+++ b/Common/Models/Shows/TraktWatchedProgress.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 /// Watched progress. Shows/Progress/Watched
-public struct TraktShowWatchedProgress: Codable {
+public struct TraktShowWatchedProgress: Codable, Hashable {
     
     // Extended: Min
     /// Number of episodes that have aired
@@ -30,7 +30,7 @@ public struct TraktShowWatchedProgress: Codable {
     }
 }
 
-public struct TraktSeasonWatchedProgress: Codable {
+public struct TraktSeasonWatchedProgress: Codable, Hashable {
     
     // Extended: Min
     /// Season number
@@ -42,7 +42,7 @@ public struct TraktSeasonWatchedProgress: Codable {
     public let episodes: [TraktEpisodeWatchedProgress]
 }
 
-public struct TraktEpisodeWatchedProgress: Codable {
+public struct TraktEpisodeWatchedProgress: Codable, Hashable {
     
     // Extended: Min
     /// Season number

--- a/Common/Models/Shows/TraktWatchedSeason.swift
+++ b/Common/Models/Shows/TraktWatchedSeason.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct TraktWatchedSeason: Codable {
+public struct TraktWatchedSeason: Codable, Hashable {
     
     // Extended: Min
     public let number: Int // Season number

--- a/Common/Models/Shows/TraktWatchedShow.swift
+++ b/Common/Models/Shows/TraktWatchedShow.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct TraktWatchedShow: Codable {
+public struct TraktWatchedShow: Codable, Hashable {
     
     // Extended: Min
     public let plays: Int // Total number of plays

--- a/Common/Models/Structures.swift
+++ b/Common/Models/Structures.swift
@@ -12,7 +12,7 @@ public typealias RawJSON = [String: Any] // Dictionary
 
 // MARK: - TV & Movies
 
-public struct ID: Codable {
+public struct ID: Codable, Hashable {
     public let trakt: Int
     public let slug: String
     public let tvdb: Int?
@@ -30,7 +30,7 @@ public struct ID: Codable {
     }
 }
 
-public struct SeasonId: Codable {
+public struct SeasonId: Codable, Hashable {
     public let trakt: Int
     public let tvdb: Int?
     public let tmdb: Int?
@@ -44,7 +44,7 @@ public struct SeasonId: Codable {
     }
 }
 
-public struct EpisodeId: Codable {
+public struct EpisodeId: Codable, Hashable {
     public let trakt: Int
     public let tvdb: Int?
     public let imdb: String?
@@ -60,7 +60,7 @@ public struct EpisodeId: Codable {
     }
 }
 
-public struct ListId: Codable {
+public struct ListId: Codable, Hashable {
     public let trakt: Int
     public let slug: String
     
@@ -72,7 +72,7 @@ public struct ListId: Codable {
 
 // MARK: - Stats
 
-public struct TraktStats: Codable {
+public struct TraktStats: Codable, Hashable {
     public let watchers: Int
     public let plays: Int
     public let collectors: Int
@@ -94,7 +94,7 @@ public struct TraktStats: Codable {
 
 // MARK: - Last Activities
 
-public struct TraktLastActivities: Codable {
+public struct TraktLastActivities: Codable, Hashable {
     public let all: Date
     public let movies: TraktLastActivityMovies
     public let episodes: TraktLastActivityEpisodes
@@ -104,7 +104,7 @@ public struct TraktLastActivities: Codable {
     public let lists: TraktLastActivityLists
 }
 
-public struct TraktLastActivityMovies: Codable {
+public struct TraktLastActivityMovies: Codable, Hashable {
     public let watchedAt: Date
     public let collectedAt: Date
     public let ratedAt: Date
@@ -124,7 +124,7 @@ public struct TraktLastActivityMovies: Codable {
     }
 }
 
-public struct TraktLastActivityEpisodes: Codable {
+public struct TraktLastActivityEpisodes: Codable, Hashable {
     public let watchedAt: Date
     public let collectedAt: Date
     public let ratedAt: Date
@@ -142,7 +142,7 @@ public struct TraktLastActivityEpisodes: Codable {
     }
 }
 
-public struct TraktLastActivityShows: Codable {
+public struct TraktLastActivityShows: Codable, Hashable {
     public let ratedAt: Date
     public let watchlistedAt: Date
     public let commentedAt: Date
@@ -156,7 +156,7 @@ public struct TraktLastActivityShows: Codable {
     }
 }
 
-public struct TraktLastActivitySeasons: Codable {
+public struct TraktLastActivitySeasons: Codable, Hashable {
     public let ratedAt: Date
     public let watchlistedAt: Date
     public let commentedAt: Date
@@ -170,7 +170,7 @@ public struct TraktLastActivitySeasons: Codable {
     }
 }
 
-public struct TraktLastActivityComments: Codable {
+public struct TraktLastActivityComments: Codable, Hashable {
     public let likedAt: Date
     
     enum CodingKeys: String, CodingKey {
@@ -178,7 +178,7 @@ public struct TraktLastActivityComments: Codable {
     }
 }
 
-public struct TraktLastActivityLists: Codable {
+public struct TraktLastActivityLists: Codable, Hashable {
     public let likedAt: Date
     public let updatedAt: Date
     public let commentedAt: Date

--- a/Common/Models/Sync/AddRatingsResult.swift
+++ b/Common/Models/Sync/AddRatingsResult.swift
@@ -8,18 +8,18 @@
 
 import Foundation
 
-public struct AddRatingsResult: Codable {
+public struct AddRatingsResult: Codable, Hashable {
     public let added: Added
 //    public let notFound: NotFound
 
-    public struct Added: Codable {
+    public struct Added: Codable, Hashable {
         public let movies: Int
         public let shows: Int
         public let seasons: Int
         public let episodes: Int
     }
     
-    public struct NotFound: Codable {
+    public struct NotFound: Codable, Hashable {
         public let movies: [ID]
         public let shows: [ID]
         public let seasons: [ID]

--- a/Common/Models/Sync/AddToCollectionResult.swift
+++ b/Common/Models/Sync/AddToCollectionResult.swift
@@ -8,18 +8,18 @@
 
 import Foundation
 
-public struct AddToCollectionResult: Codable {
+public struct AddToCollectionResult: Codable, Hashable {
     let added: Added
     let updated: Added
     let existing: Added
 //    let notFound: NotFound
 
-    public struct Added: Codable {
+    public struct Added: Codable, Hashable {
         let movies: Int
         let episodes: Int
     }
     
-    public struct NotFound: Codable {
+    public struct NotFound: Codable, Hashable {
         let movies: [ID]
         let shows: [ID]
         let seasons: [ID]

--- a/Common/Models/Sync/PlaybackProgress.swift
+++ b/Common/Models/Sync/PlaybackProgress.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct PlaybackProgress: Codable {
+public struct PlaybackProgress: Codable, Hashable {
     public let progress: Float
     public let pausedAt: Date
     public let id: Int

--- a/Common/Models/Sync/RemoveFromCollectionResult.swift
+++ b/Common/Models/Sync/RemoveFromCollectionResult.swift
@@ -8,16 +8,16 @@
 
 import Foundation
 
-public struct RemoveFromCollectionResult: Codable {
+public struct RemoveFromCollectionResult: Codable, Hashable {
     public let deleted: deleted
 //    public let notFound: NotFound
 
-    public struct deleted: Codable {
+    public struct deleted: Codable, Hashable {
         let movies: Int
         let episodes: Int
     }
     
-    public struct NotFound: Codable {
+    public struct NotFound: Codable, Hashable {
         let movies: [ID]
         let shows: [ID]
         let seasons: [ID]

--- a/Common/Models/Sync/RemoveFromWatchlistResult.swift
+++ b/Common/Models/Sync/RemoveFromWatchlistResult.swift
@@ -8,18 +8,18 @@
 
 import Foundation
 
-public struct RemoveFromWatchlistResult: Codable {
+public struct RemoveFromWatchlistResult: Codable, Hashable {
     let deleted: Deleted
 //    let notFound: NotFound
 
-    public struct Deleted: Codable {
+    public struct Deleted: Codable, Hashable {
         let movies: Int
         let shows: Int
         let seasons: Int
         let episodes: Int
     }
     
-    public struct NotFound: Codable {
+    public struct NotFound: Codable, Hashable {
         let movies: [ID]
         let shows: [ID]
         let seasons: [ID]

--- a/Common/Models/Sync/RemoveRatingsResult.swift
+++ b/Common/Models/Sync/RemoveRatingsResult.swift
@@ -8,18 +8,18 @@
 
 import Foundation
 
-public struct RemoveRatingsResult: Codable {
+public struct RemoveRatingsResult: Codable, Hashable {
     public let deleted: Deleted
 //    public let notFound: NotFound
 
-    public struct Deleted: Codable {
+    public struct Deleted: Codable, Hashable {
         public let movies: Int
         public let shows: Int
         public let seasons: Int
         public let episodes: Int
     }
     
-    public struct NotFound: Codable {
+    public struct NotFound: Codable, Hashable {
         public let movies: [ID]
         public let shows: [ID]
         public let seasons: [ID]

--- a/Common/Models/Sync/TraktCollectedItem.swift
+++ b/Common/Models/Sync/TraktCollectedItem.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct TraktCollectedItem: Codable {
+public struct TraktCollectedItem: Codable, Hashable {
     
     public var lastCollectedAt: Date
     public let lastUpdatedAt: Date
@@ -64,7 +64,7 @@ public struct TraktCollectedItem: Codable {
         }
     }
     
-    public struct Metadata: Codable {
+    public struct Metadata: Codable, Hashable {
         public let mediaType: MediaType?
         public let resolution: Resolution?
         public let hdr: HDR?
@@ -150,14 +150,14 @@ public struct TraktCollectedItem: Codable {
     }
 }
 
-public struct TraktCollectedSeason: Codable {
+public struct TraktCollectedSeason: Codable, Hashable {
     
     /// Season number
     public var number: Int
     public var episodes: [TraktCollectedEpisode]
 }
 
-public struct TraktCollectedEpisode: Codable {
+public struct TraktCollectedEpisode: Codable, Hashable {
     
     public var number: Int
     public var collectedAt: Date

--- a/Common/Models/Sync/TraktHistoryItem.swift
+++ b/Common/Models/Sync/TraktHistoryItem.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct TraktHistoryItem: Codable {
+public struct TraktHistoryItem: Codable, Hashable {
     
     public var id: Int
     public var watchedAt: Date

--- a/Common/Models/Sync/TraktRating.swift
+++ b/Common/Models/Sync/TraktRating.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct TraktRating: Codable {
+public struct TraktRating: Codable, Hashable {
     public var ratedAt: Date
     public var rating: Int
     

--- a/Common/Models/TraktSearchResult.swift
+++ b/Common/Models/TraktSearchResult.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct TraktSearchResult: Codable {
+public struct TraktSearchResult: Codable, Hashable {
     public let type: String // Can be movie, show, episode, person, list
     public let score: Double?
     

--- a/Common/Models/Users/AccountSettings.swift
+++ b/Common/Models/Users/AccountSettings.swift
@@ -8,11 +8,11 @@
 
 import Foundation
 
-public struct AccountSettings: Codable {
+public struct AccountSettings: Codable, Hashable {
     public let user: User
     public let connections: Connections
     
-    public struct Connections: Codable {
+    public struct Connections: Codable, Hashable {
         public let facebook: Bool
         public let twitter: Bool
         public let google: Bool

--- a/Common/Models/Users/FollowRequest.swift
+++ b/Common/Models/Users/FollowRequest.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct FollowRequest: Codable {
+public struct FollowRequest: Codable, Hashable {
     public let id: Int
     public let requestedAt: Date
     public let user: User
@@ -20,7 +20,7 @@ public struct FollowRequest: Codable {
     }
 }
 
-public struct FollowResult: Codable {
+public struct FollowResult: Codable, Hashable {
     public let followedAt: Date
     public let user: User
     

--- a/Common/Models/Users/FollowUserResult.swift
+++ b/Common/Models/Users/FollowUserResult.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct FollowUserResult: Codable {
+public struct FollowUserResult: Codable, Hashable {
     let approvedAt: Date
     let user: User
     

--- a/Common/Models/Users/Friend.swift
+++ b/Common/Models/Users/Friend.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct Friend: Codable {
+public struct Friend: Codable, Hashable {
     let friendsAt: Date
     let user: User
     

--- a/Common/Models/Users/HiddenItem.swift
+++ b/Common/Models/Users/HiddenItem.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct HiddenItem: Codable {
+public struct HiddenItem: Codable, Hashable {
     public let hiddenAt: Date
     public let type: String
     

--- a/Common/Models/Users/HideItemResult.swift
+++ b/Common/Models/Users/HideItemResult.swift
@@ -8,18 +8,18 @@
 
 import Foundation
 
-public struct HideItemResult: Codable {
+public struct HideItemResult: Codable, Hashable {
     
     let added: Added
 //    let notFound: NotFound
 
-    public struct Added: Codable {
+    public struct Added: Codable, Hashable {
         let movies: Int
         let shows: Int
         let seasons: Int
     }
     
-    public struct NotFound: Codable {
+    public struct NotFound: Codable, Hashable {
         let movies: [ID]
         let shows: [ID]
         let seasons: [ID]

--- a/Common/Models/Users/Likes.swift
+++ b/Common/Models/Users/Likes.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct Like: Codable {
+public struct Like: Codable, Hashable {
     public let likedAt: Date
     public let type: LikeType
     public let list: TraktList?

--- a/Common/Models/Users/ListItemPostResult.swift
+++ b/Common/Models/Users/ListItemPostResult.swift
@@ -8,12 +8,12 @@
 
 import Foundation
 
-public struct ListItemPostResult: Codable {
+public struct ListItemPostResult: Codable, Hashable {
     let added: Added
     let existing: Added
 //    let notFound: NotFound
 
-    public struct Added: Codable {
+    public struct Added: Codable, Hashable {
         let movies: Int
         let shows: Int
         let seasons: Int
@@ -21,7 +21,7 @@ public struct ListItemPostResult: Codable {
         let people: Int
     }
     
-    public struct NotFound: Codable {
+    public struct NotFound: Codable, Hashable {
         let movies: [ID]
         let shows: [ID]
         let seasons: [ID]

--- a/Common/Models/Users/RemoveListItemResult.swift
+++ b/Common/Models/Users/RemoveListItemResult.swift
@@ -8,11 +8,11 @@
 
 import Foundation
 
-public struct RemoveListItemResult: Codable {
+public struct RemoveListItemResult: Codable, Hashable {
     let deleted: Added
 //    let notFound: NotFound
 
-    public struct Added: Codable {
+    public struct Added: Codable, Hashable {
         let movies: Int
         let shows: Int
         let seasons: Int
@@ -20,7 +20,7 @@ public struct RemoveListItemResult: Codable {
         let people: Int
     }
     
-    public struct NotFound: Codable {
+    public struct NotFound: Codable, Hashable {
         let movies: [ID]
         let shows: [ID]
         let seasons: [ID]

--- a/Common/Models/Users/TraktList.swift
+++ b/Common/Models/Users/TraktList.swift
@@ -14,7 +14,7 @@ public enum ListPrivacy: String, Codable {
     case `public`
 }
 
-public struct TraktList: Codable {
+public struct TraktList: Codable, Hashable {
     public let allowComments: Bool
     public let commentCount: Int
     public let createdAt: Date?
@@ -42,7 +42,7 @@ public struct TraktList: Codable {
     }
 }
 
-public struct TraktTrendingList: Codable {
+public struct TraktTrendingList: Codable, Hashable {
     public let likeCount: Int
     public let commentCount: Int
     public let list: TraktList

--- a/Common/Models/Users/TraktListItem.swift
+++ b/Common/Models/Users/TraktListItem.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct TraktListItem: Codable {
+public struct TraktListItem: Codable, Hashable {
     public let rank: Int
     public let listedAt: Date
     public let type: String

--- a/Common/Models/Users/TraktUser.swift
+++ b/Common/Models/Users/TraktUser.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct User: Codable {
+public struct User: Codable, Hashable {
     
     // Min
     public let username: String?

--- a/Common/Models/Users/TraktWatchedItem.swift
+++ b/Common/Models/Users/TraktWatchedItem.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct TraktWatchedItem: Codable {
+public struct TraktWatchedItem: Codable, Hashable {
     public let plays: Int
     public let lastWatchedAt: Date
     public var show: TraktShow? = nil
@@ -23,11 +23,11 @@ public struct TraktWatchedItem: Codable {
         case movie
     }
 
-    public struct TraktWatchedSeason: Codable {
+    public struct TraktWatchedSeason: Codable, Hashable {
         public let number: Int
         public let episodes: [TraktWatchedEpisode]?
 
-        public struct TraktWatchedEpisode: Codable {
+        public struct TraktWatchedEpisode: Codable, Hashable {
             public let number: Int
             public let plays: Int
             public let lastWatchedAt: Date

--- a/Common/Models/Users/TraktWatching.swift
+++ b/Common/Models/Users/TraktWatching.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct TraktWatching: Codable {
+public struct TraktWatching: Codable, Hashable {
     public let expiresAt: Date
     public let startedAt: Date
     public let action: String

--- a/Common/Models/Users/UnhideItemResult.swift
+++ b/Common/Models/Users/UnhideItemResult.swift
@@ -8,17 +8,17 @@
 
 import Foundation
 
-public struct UnhideItemResult: Codable {
+public struct UnhideItemResult: Codable, Hashable {
     let deleted: Deleted
 //    let notFound: NotFound
 
-    public struct Deleted: Codable {
+    public struct Deleted: Codable, Hashable {
         let movies: Int
         let shows: Int
         let seasons: Int
     }
     
-    public struct NotFound: Codable {
+    public struct NotFound: Codable, Hashable {
         let movies: [ID]
         let shows: [ID]
         let seasons: [ID]

--- a/Common/Models/Users/UserStats.swift
+++ b/Common/Models/Users/UserStats.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct UserStats: Codable {
+public struct UserStats: Codable, Hashable {
     let movies: Movies
     let shows: Shows
     let seasons: Seasons
@@ -16,7 +16,7 @@ public struct UserStats: Codable {
     let network: Network
     let ratings: UserStatsRatingsDistribution
     
-    public struct Movies: Codable {
+    public struct Movies: Codable, Hashable {
         let plays: Int
         let watched: Int
         let minutes: Int
@@ -25,19 +25,19 @@ public struct UserStats: Codable {
         let comments: Int
     }
     
-    public struct Shows: Codable {
+    public struct Shows: Codable, Hashable {
         let watched: Int
         let collected: Int
         let ratings: Int
         let comments: Int
     }
     
-    public struct Seasons: Codable {
+    public struct Seasons: Codable, Hashable {
         let ratings: Int
         let comments: Int
     }
     
-    public struct Episodes: Codable {
+    public struct Episodes: Codable, Hashable {
         let plays: Int
         let watched: Int
         let minutes: Int
@@ -46,17 +46,17 @@ public struct UserStats: Codable {
         let comments: Int
     }
     
-    public struct Network: Codable {
+    public struct Network: Codable, Hashable {
         let friends: Int
         let followers: Int
         let following: Int
     }
     
-    public struct UserStatsRatingsDistribution: Codable {
+    public struct UserStatsRatingsDistribution: Codable, Hashable {
         let total: Int
         let distribution: Distribution
         
-        public struct Distribution: Codable {
+        public struct Distribution: Codable, Hashable {
             public let one: Int
             public let two: Int
             public let three: Int

--- a/Common/Models/Users/UsersComments.swift
+++ b/Common/Models/Users/UsersComments.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct UsersComments: Codable {
+public struct UsersComments: Codable, Hashable {
     public let type: String
     public let comment: Comment
     public let movie: TraktMovie?

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,27 @@
+// swift-tools-version:5.0
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "TraktKit",
+    platforms: [
+        .macOS(.v10_12),
+        .iOS(.v10),
+        .tvOS(.v10),
+        .watchOS(.v3)
+    ],
+    products: [
+        .library(
+            name: "TraktKit",
+            targets: ["TraktKit"]),
+    ],
+    targets: [
+        .target(
+            name: "TraktKit",
+            dependencies: [],
+            path: "Common"
+            )
+    ],
+    swiftLanguageVersions: [.v5]
+)

--- a/README.md
+++ b/README.md
@@ -54,6 +54,17 @@ github "MaxHasADHD/TraktKit"
 
 Run `carthage update` to build the framework and drag the built `TraktKit.framework` into your Xcode project.    
 
+### Swift Package Manager
+
+You can use Xcode 11 or later to integrate TraktKit into your project using [Swift Package Manager](https://developer.apple.com/documentation/xcode/adding_package_dependencies_to_your_app).
+
+To integrate TraktKit into your Xcode project using Swift Package Manager. Select **File > Swift Packages > Add Package Dependency...**.
+
+When prompted, simply search for TraktKit or specify the project's GitHub repository:
+
+```git@github.com:MaxHasADHD/TraktKit.git
+```
+
 ### Usage
 See the [example project](https://github.com/MaxHasADHD/TraktKit/tree/master/Example) for usage
 

--- a/TraktKit.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/TraktKit.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -2,6 +2,9 @@
 <Workspace
    version = "1.0">
    <FileRef
-      location = "self:TraktKit.xcodeproj">
+      location = "group:../Package.swift">
+   </FileRef>
+   <FileRef
+      location = "self:">
    </FileRef>
 </Workspace>


### PR DESCRIPTION
Conforming all of TraktKit's models to Hashable both has no ill effects on its current functionality, and allows for one to use the model objects as identifiers, such as when using [`UICollectionViewDiffableDataSource`](https://developer.apple.com/documentation/uikit/uicollectionviewdiffabledatasource).

This pull request adds `Hashable` to all Model structs, without modifying their functionality.

This pull request also contains a `Package.swift` file to support [Swift Package Manager](https://developer.apple.com/documentation/xcode/adding_package_dependencies_to_your_app). I realize this is already covered in open PR #35, but with that PR being fairly stale (and tbh, my personal needs in my own project), I've added that here too.