### PR TITLE
Fix getPeopleInEpisode

### DIFF
--- a/Common/Models/People/TraktCastMember.swift
+++ b/Common/Models/People/TraktCastMember.swift
@@ -13,7 +13,7 @@ public struct TVCastMember: Codable, Hashable {
     public let characters: [String]
     @available(*, deprecated, renamed: "characters")
     public let character: String
-    public let episodeCount: Int
+    public let episodeCount: Int?
     public let person: Person
     
     enum CodingKeys: String, CodingKey {

--- a/Common/Models/People/TraktCrewMember.swift
+++ b/Common/Models/People/TraktCrewMember.swift
@@ -13,7 +13,7 @@ public struct TVCrewMember: Codable, Hashable {
     public let jobs: [String]
     @available(*, deprecated, renamed: "jobs")
     public let job: String
-    public let episodeCount: Int
+    public let episodeCount: Int?
     public let person: Person
     
     enum CodingKeys: String, CodingKey {

--- a/TraktKitTests/EpisodeTests.swift
+++ b/TraktKitTests/EpisodeTests.swift
@@ -230,14 +230,17 @@ class EpisodeTests: XCTestCase {
         traktManager.getPeopleInEpisode(showID: "game-of-thrones", season: 1, episode: 1) { result in
             if case .success(let castAndCrew) = result {
                 XCTAssertNotNil(castAndCrew.cast)
-                XCTAssertNotNil(castAndCrew.producers)
+                XCTAssertNotNil(castAndCrew.writers)
                 XCTAssertEqual(castAndCrew.cast!.count, 20)
-                XCTAssertEqual(castAndCrew.producers!.count, 14)
+				XCTAssertEqual(castAndCrew.writers!.count, 2)
                 
                 guard let actor = castAndCrew.cast?.first else { XCTFail("Cast is empty"); return }
                 XCTAssertEqual(actor.person.name, "Emilia Clarke")
                 XCTAssertEqual(actor.characters, ["Daenerys Targaryen"])
             }
+			else {
+				XCTFail("Invalid result")
+			}
             expectation.fulfill()
         }
         let result = XCTWaiter().wait(for: [expectation], timeout: 5)


### PR DESCRIPTION
Calls to getPeopleInEpisode failed due to "episode_count" not being present for single episodes. In TVCastMember and TVCrewMember episodeCount needed to be optional to parse successfully.

The unit test for getPeopleInEpisode reported success, but was actually failing and did not check the returned values as there was no check for the result itself being invalid.